### PR TITLE
Don't re-install datadog-agent if installed

### DIFF
--- a/lib/itamae/plugin/recipe/datadog/install.rb
+++ b/lib/itamae/plugin/recipe/datadog/install.rb
@@ -7,6 +7,12 @@ node.reverse_merge!(
 
 execute 'download install script' do
   command 'wget https://raw.githubusercontent.com/DataDog/datadog-agent/main/cmd/agent/install_script.sh -O /tmp/install_script.sh'
+
+  # If upgrade is enabled, always download the latest install_script.sh
+  # If upgrade is disabled, download only when `/tmp/install_script.sh` doesn't exist
+  unless node[:datadog][:upgrade]
+    not_if 'ls /tmp/install_script.sh'
+  end
 end
 
 file '/tmp/install_script.sh' do

--- a/lib/itamae/plugin/recipe/datadog/install.rb
+++ b/lib/itamae/plugin/recipe/datadog/install.rb
@@ -27,4 +27,10 @@ execute 'install datadog-agent' do
   options['DD_UPGRADE'] = 'true' if node[:datadog][:upgrade]
   option_str = options.map { |k, v| "#{k}=#{v}" }.join(' ')
   command "#{option_str} /tmp/install_script.sh"
+
+  # If upgrade is enabled, always run `install_script.sh`
+  # If upgrade is disabled, run `install_script.sh` only when datadog isn't installed
+  unless node[:datadog][:upgrade]
+    not_if 'ls /etc/datadog-agent/datadog.yaml'
+  end
 end

--- a/lib/itamae/plugin/recipe/datadog/install.rb
+++ b/lib/itamae/plugin/recipe/datadog/install.rb
@@ -6,7 +6,7 @@ node.reverse_merge!(
 )
 
 execute 'download install script' do
-  command 'wget https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh -O /tmp/install_script.sh'
+  command 'wget https://raw.githubusercontent.com/DataDog/datadog-agent/main/cmd/agent/install_script.sh -O /tmp/install_script.sh'
 end
 
 file '/tmp/install_script.sh' do


### PR DESCRIPTION
## What
If `node[:datadog][:upgrade]` is disabled, don't download and run `install_script.sh`

## Why
Currently, even if datadog-agent is already installed, the script is downloaded and executed and Itamae takes a little time to run.

I would therefore like to avoid downloading and executing scripts when not needed.

## How
See my codes.

## Changes
### Before
```
$ itamae ssh --host host-01 --node-yaml node.yml --log-level info cookbooks/default.rb

(snip)

/path/to/app/vendor/bundle/ruby/3.1.0/gems/itamae-plugin-recipe-datadog-0.2.0/lib/itamae/plugin/recipe/datadog/install.rb
 INFO :         execute[download install script] executed will change from 'false' to 'true'
 INFO :         file[/tmp/install_script.sh] mode will change from '0644' to '0755'
 INFO :         execute[install datadog-agent] executed will change from 'false' to 'true'

real	0m17.319s
user	0m2.341s
sys	0m0.435s
```

### After
```
$ itamae ssh --host host-01 --node-yaml node.yml --log-level info cookbooks/default.rb

(snip)

 INFO :       Recipe: /Users/sue445/workspace/github.com/speee/itamae-plugin-recipe-datadog/lib/itamae/plugin/recipe/datadog/install.rb

real	0m10.089s
user	0m2.217s
sys	0m0.430s
```
