### PR TITLE
Removed Speee, Inc. from LICENSE

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 takanamito and Speee, Inc.
+Copyright (c) 2016 takanamito
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This repository was originally under [speee org](https://github.com/speee).

However, it has now been transferred to [itamae-plugins org](https://github.com/itamae-plugins), so this description of the license does not seem appropriate.

Therefore, it has been removed.

@takanamito What do you think?